### PR TITLE
Update project for Godot v4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Godot-specific ignores
 .import/
+.godot/
 export.cfg
 export_presets.cfg
 

--- a/src/default_env.tres
+++ b/src/default_env.tres
@@ -1,9 +1,8 @@
-[gd_resource type="Environment" load_steps=2 format=2]
+[gd_resource type="Environment" load_steps=2 format=3 uid="uid://dorikak6maspd"]
 
-[sub_resource type="ProceduralSky" id=1]
+[sub_resource type="Sky" id="1"]
 
 [resource]
 background_mode = 1
-background_sky = SubResource( 1 )
-background_color = Color( 0.231373, 0.231373, 0.231373, 1 )
-background_energy = 0.0
+background_color = Color(0.231373, 0.231373, 0.231373, 1)
+sky = SubResource("1")

--- a/src/icon.png.import
+++ b/src/icon.png.import
@@ -1,37 +1,35 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path.s3tc="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.s3tc.stex"
-path.etc2="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.etc2.stex"
+type="CompressedTexture2D"
+uid="uid://b511iiymyd82y"
+path.s3tc="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.s3tc.ctex"
 metadata={
-"imported_formats": [ "s3tc", "etc2" ],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://icon.png"
-dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.s3tc.stex", "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.etc2.stex" ]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=1
-flags/repeat=true
-flags/filter=true
-flags/mipmaps=true
-flags/anisotropic=false
-flags/srgb=1
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/src/models/models.glb.import
+++ b/src/models/models.glb.import
@@ -11,7 +11,7 @@ dest_files=[ "res://.import/models.glb-44e1707e7272883458c491f4d2b665b7.scn" ]
 
 [params]
 
-nodes/root_type="Spatial"
+nodes/root_type="Node3D"
 nodes/root_name="Scene Root"
 nodes/root_scale=1.0
 nodes/custom_script=""

--- a/src/project.godot
+++ b/src/project.godot
@@ -6,22 +6,13 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
-
-_global_script_classes=[ {
-"base": "Spatial",
-"class": "Catenary",
-"language": "GDScript",
-"path": "res://scripts/catenary.gd"
-} ]
-_global_script_class_icons={
-"Catenary": ""
-}
+config_version=5
 
 [application]
 
 config/name="CatenaryTest"
 run/main_scene="res://scenes/demo.tscn"
+config/features=PackedStringArray("4.4")
 config/icon="res://icon.png"
 
 [gui]
@@ -34,4 +25,4 @@ common/enable_pause_aware_picking=true
 
 [rendering]
 
-environment/default_environment="res://default_env.tres"
+environment/defaults/default_environment="res://default_env.tres"

--- a/src/scenes/cables.tscn
+++ b/src/scenes/cables.tscn
@@ -3,50 +3,50 @@
 [ext_resource path="res://scripts/catenary.gd" type="Script" id=1]
 [ext_resource path="res://models/models_Cable.mesh" type="ArrayMesh" id=2]
 
-[node name="Cables" type="Spatial"]
+[node name="Cables" type="Node3D"]
 
-[node name="DirectionalLight" type="DirectionalLight" parent="."]
-transform = Transform( 0.756368, -2.85937e-08, 0.654147, -0.654147, -3.30619e-08, 0.756368, 0, -1, -4.37114e-08, 3.14969, 0, -1 )
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D( 0.756368, -2.85937e-08, 0.654147, -0.654147, -3.30619e-08, 0.756368, 0, -1, -4.37114e-08, 3.14969, 0, -1 )
 light_energy = 6.292
 
-[node name="Cable2" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.24614, 2.38419e-07, 1.08669 )
+[node name="Cable2" type="Node3D" parent="."]
+transform = Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.24614, 2.38419e-07, 1.08669 )
 script = ExtResource( 1 )
 mesh = ExtResource( 2 )
 target_path = NodePath("../Target0")
 width = 0.7
 swing_frequency = 1.0
 
-[node name="Cable3" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -4.07669, 0, -4.33296 )
+[node name="Cable3" type="Node3D" parent="."]
+transform = Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, -4.07669, 0, -4.33296 )
 script = ExtResource( 1 )
 mesh = ExtResource( 2 )
 target_path = NodePath("../Target0")
 width = 1.45
 swing_frequency = 1.0
 
-[node name="Cable4" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.95956, 2.38419e-07, -2.90587 )
+[node name="Cable4" type="Node3D" parent="."]
+transform = Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.95956, 2.38419e-07, -2.90587 )
 script = ExtResource( 1 )
 mesh = ExtResource( 2 )
 target_path = NodePath("../Target0")
 width = 1.15
 swing_frequency = 1.0
 
-[node name="Cable5" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -4.20576, 2.38419e-07, -1.76878 )
+[node name="Cable5" type="Node3D" parent="."]
+transform = Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, -4.20576, 2.38419e-07, -1.76878 )
 script = ExtResource( 1 )
 mesh = ExtResource( 2 )
 target_path = NodePath("../Target0")
 swing_frequency = 1.0
 
-[node name="Cable6" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.97181, -0.00399196, -0.322159 )
+[node name="Cable6" type="Node3D" parent="."]
+transform = Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.97181, -0.00399196, -0.322159 )
 script = ExtResource( 1 )
 mesh = ExtResource( 2 )
 target_path = NodePath("../Target0")
 width = 0.93
 swing_frequency = 1.0
 
-[node name="Target0" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0180654, -0.075443, 0 )
+[node name="Target0" type="Node3D" parent="."]
+transform = Transform3D( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0180654, -0.075443, 0 )

--- a/src/scenes/demo.tscn
+++ b/src/scenes/demo.tscn
@@ -1,155 +1,155 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=7 format=3 uid="uid://4yobalvr4jhj"]
 
-[ext_resource path="res://scripts/catenary.gd" type="Script" id=1]
-[ext_resource path="res://models/models_ChainShort.mesh" type="ArrayMesh" id=2]
-[ext_resource path="res://scripts/suzanne.gd" type="Script" id=3]
-[ext_resource path="res://models/models_Room.mesh" type="ArrayMesh" id=4]
-[ext_resource path="res://models/models_Chain.mesh" type="ArrayMesh" id=5]
-[ext_resource path="res://models/models_Suzanne.mesh" type="ArrayMesh" id=6]
+[ext_resource type="Script" uid="uid://bxbkgpvdk3e8p" path="res://scripts/catenary.gd" id="1"]
+[ext_resource type="ArrayMesh" path="res://models/models_ChainShort.mesh" id="2"]
+[ext_resource type="Script" uid="uid://ndlckk32um6o" path="res://scripts/suzanne.gd" id="3"]
+[ext_resource type="ArrayMesh" path="res://models/models_Room.mesh" id="4"]
+[ext_resource type="ArrayMesh" uid="uid://ukuq1ts6bfxj" path="res://models/models_Chain.mesh" id="5"]
+[ext_resource type="ArrayMesh" path="res://models/models_Suzanne.mesh" id="6"]
 
-[node name="Spatial" type="Spatial"]
+[node name="Node3D" type="Node3D"]
 
-[node name="ChainShort1" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.22958, 2.82718, 3.47717 )
-script = ExtResource( 1 )
-mesh = ExtResource( 2 )
+[node name="ChainShort1" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.22958, 2.82718, 3.47717)
+script = ExtResource("1")
+mesh = ExtResource("2")
 target_path = NodePath("../Suzanne/Anchor001")
 length = 4.688
 width = 0.33
 swing_frequency = 1.0
 
-[node name="ChainShort2" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2.74517, 2.71859, 3.77425 )
-script = ExtResource( 1 )
-mesh = ExtResource( 2 )
+[node name="ChainShort2" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.74517, 2.71859, 3.77425)
+script = ExtResource("1")
+mesh = ExtResource("2")
 target_path = NodePath("../Suzanne/Anchor002")
 length = 4.558
 width = 0.33
 swing_frequency = 1.0
 
-[node name="Chain1" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.17402, 2.86761, -4.05181 )
-script = ExtResource( 1 )
-mesh = ExtResource( 5 )
+[node name="Chain1" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.17402, 2.86761, -4.05181)
+script = ExtResource("1")
+mesh = ExtResource("5")
 target_path = NodePath("../Suzanne/Anchor000")
 length = 4.026
 width = 0.26
 swing_frequency = 1.0
 
-[node name="Chain2" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.91698, 2.83535, 0.0443848 )
-script = ExtResource( 1 )
-mesh = ExtResource( 5 )
+[node name="Chain2" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.91698, 2.83535, 0.0443848)
+script = ExtResource("1")
+mesh = ExtResource("5")
 target_path = NodePath("../Suzanne/Anchor003")
 length = 3.888
 width = 0.33
 swing_frequency = 1.0
 
-[node name="Chain3" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4.04294, 2.86978, 2.58682 )
-script = ExtResource( 1 )
-mesh = ExtResource( 5 )
+[node name="Chain3" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.04294, 2.86978, 2.58682)
+script = ExtResource("1")
+mesh = ExtResource("5")
 target_path = NodePath("../Suzanne/Anchor004")
 length = 4.809
 width = 0.25
 swing_frequency = 1.0
 
-[node name="Chain4" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.05024, 3.25621, -1.74377 )
-script = ExtResource( 1 )
-mesh = ExtResource( 5 )
+[node name="Chain4" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.05024, 3.25621, -1.74377)
+script = ExtResource("1")
+mesh = ExtResource("5")
 target_path = NodePath("../Suzanne/Anchor005")
 length = 4.187
 width = 0.33
 swing_frequency = 1.0
 
-[node name="Chain5" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4.04294, 2.83522, -1.56389 )
-script = ExtResource( 1 )
-mesh = ExtResource( 5 )
+[node name="Chain5" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.04294, 2.83522, -1.56389)
+script = ExtResource("1")
+mesh = ExtResource("5")
 target_path = NodePath("../Suzanne/Anchor006")
 length = 4.453
 width = 0.33
 swing_frequency = 1.0
 
-[node name="Chain6" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -1.15073, 2.8629, -3.79759 )
-script = ExtResource( 1 )
-mesh = ExtResource( 5 )
+[node name="Chain6" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.15073, 2.8629, -3.79759)
+script = ExtResource("1")
+mesh = ExtResource("5")
 target_path = NodePath("../Suzanne/Anchor007")
 length = 4.052
 width = 0.33
 swing_frequency = 1.0
 
-[node name="Chain7" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3.69992, 2.93042, -0.691847 )
-script = ExtResource( 1 )
-mesh = ExtResource( 5 )
+[node name="Chain7" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.69992, 2.93042, -0.691847)
+script = ExtResource("1")
+mesh = ExtResource("5")
 target_path = NodePath("../Suzanne/Anchor008")
 length = 4.043
 width = 0.25
 swing_frequency = 1.0
 
-[node name="Chain8" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3.12478, 2.86102, -3.90132 )
-script = ExtResource( 1 )
-mesh = ExtResource( 5 )
+[node name="Chain8" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.12478, 2.86102, -3.90132)
+script = ExtResource("1")
+mesh = ExtResource("5")
 target_path = NodePath("../Suzanne/Anchor009")
 width = 0.33
 swing_frequency = 1.0
 
-[node name="Suzanne" type="MeshInstance" parent="."]
-transform = Transform( 0.876315, 0.150321, -0.457683, -0.10863, 0.987258, 0.116263, 0.469329, -0.0521651, 0.88148, -0.157481, 1.33624, -0.148738 )
-mesh = ExtResource( 6 )
+[node name="Suzanne" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.913411, 0.284493, -0.291104, -0.197587, 0.935171, 0.293957, 0.355862, -0.210985, 0.91041, -0.460443, 1.08021, 0.498701)
+mesh = ExtResource("6")
 skeleton = NodePath("")
-script = ExtResource( 3 )
+script = ExtResource("3")
 
-[node name="Anchor000" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0396748, 0.209795, -0.477801 )
+[node name="Anchor000" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0396748, 0.209795, -0.477801)
 
-[node name="Anchor001" type="Spatial" parent="Suzanne"]
-transform = Transform( 0.0213963, 0.575759, 0.81734, -0.527195, 0.701125, -0.480093, -0.849475, -0.420625, 0.318538, -0.349, -0.012, 0.13 )
+[node name="Anchor001" type="Node3D" parent="Suzanne"]
+transform = Transform3D(0.0213963, 0.575759, 0.81734, -0.527195, 0.701125, -0.480093, -0.849475, -0.420625, 0.318538, -0.349, -0.012, 0.13)
 
-[node name="Anchor002" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.12166, 0.424054, 0.414956 )
+[node name="Anchor002" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.12166, 0.424054, 0.414956)
 
-[node name="Anchor003" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.439569, 0.298872, 0.281852 )
+[node name="Anchor003" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.439569, 0.298872, 0.281852)
 
-[node name="Anchor004" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.439232, 0.308502, 0.107123 )
+[node name="Anchor004" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.439232, 0.308502, 0.107123)
 
-[node name="Anchor005" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.133481, -0.497473, 0.223953 )
+[node name="Anchor005" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.133481, -0.497473, 0.223953)
 
-[node name="Anchor006" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.169794, -0.513085, 0.252107 )
+[node name="Anchor006" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.169794, -0.513085, 0.252107)
 
-[node name="Anchor007" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0515912, 0.0299631, -0.413133 )
+[node name="Anchor007" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0515912, 0.0299631, -0.413133)
 
-[node name="Anchor008" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.298665, 0.029201, -0.313735 )
+[node name="Anchor008" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.298665, 0.029201, -0.313735)
 
-[node name="Anchor009" type="Spatial" parent="Suzanne"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.375293, 0.0180749, -0.253593 )
+[node name="Anchor009" type="Node3D" parent="Suzanne"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.375293, 0.0180749, -0.253593)
 
-[node name="Room" type="MeshInstance" parent="."]
-mesh = ExtResource( 4 )
+[node name="Room" type="MeshInstance3D" parent="."]
+mesh = ExtResource("4")
 skeleton = NodePath("")
 
-[node name="OmniLight" type="OmniLight" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -1.26408, 2.33728, 0 )
+[node name="OmniLight3D" type="OmniLight3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.26408, 2.33728, 0)
 shadow_enabled = true
 
-[node name="OmniLight2" type="OmniLight" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 1.64791, 2.16803, 0 )
+[node name="OmniLight2" type="OmniLight3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.64791, 2.16803, 0)
 shadow_enabled = true
 
-[node name="OmniLight3" type="OmniLight" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.254056, 2.29067, 1.21106 )
+[node name="OmniLight3" type="OmniLight3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.254056, 2.29067, 1.21106)
 shadow_enabled = true
 
-[node name="SpotLight" type="SpotLight" parent="."]
-transform = Transform( 1, 0, 0, 0, 0.666038, 0.745918, 0, -0.745918, 0.666038, 0, 2.65961, 1.57917 )
+[node name="SpotLight3D" type="SpotLight3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.666038, 0.745918, 0, -0.745918, 0.666038, 0, 2.65961, 1.57917)
 shadow_enabled = true

--- a/src/scripts/catenary.gd
+++ b/src/scripts/catenary.gd
@@ -1,13 +1,13 @@
 """
-    Asset: Godot Dynamic Catenary
-    File: catenary.gd
-    Description: Node for drawing a catenary between two points using the catenary shader.
-                 Based on algorithms from https://www.alanzucconi.com/2020/12/13/catenary-2/
-    Instructions: The script will create a temporary mesh instance for the catenary.
-                  The position of this node acts as the starting point for the catenary.
-                  Assign the target path to another spatial node which will act as the end point.
-    Repository: https://github.com/Donitzo/godot-catenary
-    License: MIT License
+	Asset: Godot Dynamic Catenary
+	File: catenary.gd
+	Description: Node for drawing a catenary between two points using the catenary shader.
+				 Based on algorithms from https://www.alanzucconi.com/2020/12/13/catenary-2/
+	Instructions: The script will create a temporary mesh instance for the catenary.
+				  The position of this node acts as the starting point for the catenary.
+				  Assign the target path to another spatial node which will act as the end point.
+	Repository: https://github.com/Donitzo/godot-catenary
+	License: MIT License
 """
 
 @tool
@@ -51,176 +51,176 @@ var _mesh_instance:MeshInstance3D
 var _material:ShaderMaterial
 
 func _set_mesh(v:Mesh) -> void:
-    if v != mesh:
-        mesh = v
+	if v != mesh:
+		mesh = v
 
-        _create_mesh_instance()
-        _update_curve()
+		_create_mesh_instance()
+		_update_curve()
 
 func _set_target_path(v:NodePath) -> void:
-    target_path = v
-    _target_node = null
+	target_path = v
+	_target_node = null
 
-    _update_curve()
+	_update_curve()
 
 func _set_track_target(v:bool) -> void:
-    track_target = v
+	track_target = v
 
-    set_process(track_target or Engine.is_editor_hint())
+	set_process(track_target or Engine.is_editor_hint())
 
 func _set_length(v:float) -> void:
-    length = v
+	length = v
 
-    _update_curve()
+	_update_curve()
 
 func _set_width(v:float) -> void:
-    width = v
+	width = v
 
-    if _material != null:
-        _material.set_shader_parameter("width", width)
+	if _material != null:
+		_material.set_shader_parameter("width", width)
 
 func _set_swing_angle(v:float) -> void:
-    swing_angle = v
+	swing_angle = v
 
-    if _material != null:
-        _material.set_shader_parameter("swing_angle", swing_angle)
+	if _material != null:
+		_material.set_shader_parameter("swing_angle", swing_angle)
 
 func _set_swing_frequency(v:float) -> void:
-    swing_frequency = v
+	swing_frequency = v
 
-    if _material != null:
-        _material.set_shader_parameter("swing_frequency", swing_frequency)
+	if _material != null:
+		_material.set_shader_parameter("swing_frequency", swing_frequency)
 
 func _notification(what) -> void:
-    if what == NOTIFICATION_TRANSFORM_CHANGED:
-        _update_curve()
+	if what == NOTIFICATION_TRANSFORM_CHANGED:
+		_update_curve()
 
 func _ready() -> void:
-    _update_curve()
+	_update_curve()
 
 func _process(_delta:float) -> void:
-    if _target_node != null and _target_position != _target_node.global_position:
-        _update_curve()
+	if _target_node != null and _target_position != _target_node.global_position:
+		_update_curve()
 
 func _create_mesh_instance() -> void:
-    if mesh == null:
-        return
+	if mesh == null:
+		return
 
-    # Enable transform notifications for this spatial
-    set_notify_transform(true)
+	# Enable transform notifications for this spatial
+	set_notify_transform(true)
 
-    # Create a catenary material
-    if _material == null:
-        _material = ShaderMaterial.new()
-        _material.shader = preload("res://shaders/catenary.tres")
-        _material.set_shader_parameter("width", width)
-        _material.set_shader_parameter("swing_phase_offset", randf_range(0, PI * 2))
-        _material.set_shader_parameter("swing_angle", swing_angle)
-        _material.set_shader_parameter("swing_frequency", swing_frequency)
+	# Create a catenary material
+	if _material == null:
+		_material = ShaderMaterial.new()
+		_material.shader = preload("res://shaders/catenary.tres")
+		_material.set_shader_parameter("width", width)
+		_material.set_shader_parameter("swing_phase_offset", randf_range(0, PI * 2))
+		_material.set_shader_parameter("swing_angle", swing_angle)
+		_material.set_shader_parameter("swing_frequency", swing_frequency)
 
-    # Remove any old mesh instance (updating old instance doesn't work in editor)
-    if _mesh_instance != null:
-        remove_child(_mesh_instance)
+	# Remove any old mesh instance (updating old instance doesn't work in editor)
+	if _mesh_instance != null:
+		remove_child(_mesh_instance)
 
-        _mesh_instance.queue_free()
+		_mesh_instance.queue_free()
 
-    # Create the catenary mesh instance as a child node of this spatial.
-    _mesh_instance = MeshInstance3D.new()
-    _mesh_instance.name = "Catenary"
-    _mesh_instance.mesh = mesh
-    _mesh_instance.material_override = _material
-    _mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	# Create the catenary mesh instance as a child node of this spatial.
+	_mesh_instance = MeshInstance3D.new()
+	_mesh_instance.name = "Catenary"
+	_mesh_instance.mesh = mesh
+	_mesh_instance.material_override = _material
+	_mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
-    add_child(_mesh_instance)
+	add_child(_mesh_instance)
 
-    # If no mesh is assigned, just create an empty mesh instance
-    if mesh == null:
-        return
+	# If no mesh is assigned, just create an empty mesh instance
+	if mesh == null:
+		return
 
-    # The mesh size is required for scaling the catenary
-    var aabb:AABB = mesh.get_aabb()
-    _material.set_shader_parameter("minmax_x", Vector2(aabb.position.x, aabb.end.x))
+	# The mesh size is required for scaling the catenary
+	var aabb:AABB = mesh.get_aabb()
+	_material.set_shader_parameter("minmax_x", Vector2(aabb.position.x, aabb.end.x))
 
-    # You may need to replace these uniforms based on what kind of shader is used on the mesh.
-    # These uniforms act as a standard SchlickGGX shader in Godot.
-    var material:ShaderMaterial = mesh.surface_get_material(0)
-    _material.set_shader_parameter("albedo", material.get_shader_parameter('albedo'))
+	# You may need to replace these uniforms based on what kind of shader is used on the mesh.
+	# These uniforms act as a standard SchlickGGX shader in Godot.
+	var material:StandardMaterial3D = mesh.surface_get_material(0)
+	_material.set_shader_parameter("albedo", material.albedo_texture)
 
 func _update_curve() -> void:
-    # Create a mesh instance of none exists
-    if _mesh_instance == null:
-        _create_mesh_instance()
+	# Create a mesh instance of none exists
+	if _mesh_instance == null:
+		_create_mesh_instance()
 
-    # Get the target node
-    if _target_node == null:
-        if is_inside_tree() and not target_path.is_empty():
-            _target_node = get_node(target_path)
-        else:
-            return
+	# Get the target node
+	if _target_node == null:
+		if is_inside_tree() and not target_path.is_empty():
+			_target_node = get_node(target_path)
+		else:
+			return
 
-    var start:Vector3 = global_position
-    var target:Vector3 = _target_node.global_position
+	var start:Vector3 = global_position
+	var target:Vector3 = _target_node.global_position
 
-    _target_position = target
+	_target_position = target
 
-    # Flip start and end point so that p0 is always the lowest
-    var flip:bool = target.y < start.y
-    var p0:Vector3 = target if flip else start
-    var p1:Vector3 = start if flip else target
+	# Flip start and end point so that p0 is always the lowest
+	var flip:bool = target.y < start.y
+	var p0:Vector3 = target if flip else start
+	var p1:Vector3 = start if flip else target
 
-    # Get the catenary arc length
-    var shift:Vector3 = p1 - p0
-    var l:float = max(shift.length() * 1.0001, length)
+	# Get the catenary arc length
+	var shift:Vector3 = p1 - p0
+	var l:float = max(shift.length() * 1.0001, length)
 
-    # Approximate the "a" parameter of the catenary expression
-    # See formulas at https://www.alanzucconi.com/2020/12/13/catenary-2/
+	# Approximate the "a" parameter of the catenary expression
+	# See formulas at https://www.alanzucconi.com/2020/12/13/catenary-2/
 
-    var h:float = sqrt(shift.x * shift.x + shift.z * shift.z)
-    var v:float = shift.y
-    var c:float = sqrt(l * l - v * v)
+	var h:float = sqrt(shift.x * shift.x + shift.z * shift.z)
+	var v:float = shift.y
+	var c:float = sqrt(l * l - v * v)
 
-    if h == 0:
-        return
+	if h == 0:
+		return
 
-    # Exponentially grow "a" range to a maximum of 2^32
+	# Exponentially grow "a" range to a maximum of 2^32
 
-    var a_min:float = 0
-    var a_max:float = 1
+	var a_min:float = 0
+	var a_max:float = 1
 
-    var i:int = 0
+	var i:int = 0
 
-    while i < 32 and c < 2 * a_max * sinh(h / (2 * a_max)):
-        i += 1
-        a_min = a_max
-        a_max *= 2
+	while i < 32 and c < 2 * a_max * sinh(h / (2 * a_max)):
+		i += 1
+		a_min = a_max
+		a_max *= 2
 
-    # Binary search for "a" parameter
+	# Binary search for "a" parameter
 
-    i += _a_search_min_iterations
+	i += _a_search_min_iterations
 
-    var a:float
+	var a:float
 
-    while i > 0:
-        i -= 1
-        a = (a_min + a_max) * 0.5
-        if c < 2 * a * sinh(h / (2 * a)):
-            a_min = a
-        else:
-            a_max = a
+	while i > 0:
+		i -= 1
+		a = (a_min + a_max) * 0.5
+		if c < 2 * a * sinh(h / (2 * a)):
+			a_min = a
+		else:
+			a_max = a
 
-    # Calculate "p" and "q" parameters based on catenary arc length and "a"
-    var p:float = (h - a * log((l + v) / (l - v))) / 2
-    var q:float = (v - l * (1 / tanh(h / (2 * a)))) / 2
+	# Calculate "p" and "q" parameters based on catenary arc length and "a"
+	var p:float = (h - a * log((l + v) / (l - v))) / 2
+	var q:float = (v - l * (1 / tanh(h / (2 * a)))) / 2
 
-    # Add the catenary arc length to the cull margin (this size is often larger than required)
-    var ref:Node = self
-    if ref is MeshInstance3D:
-        ref.extra_cull_margin = l + 1
-    _mesh_instance.extra_cull_margin = l + 1
+	# Add the catenary arc length to the cull margin (this size is often larger than required)
+	var ref:Node = self
+	if ref is MeshInstance3D:
+		ref.extra_cull_margin = l + 1
+	_mesh_instance.extra_cull_margin = l + 1
 
-    # Set shader uniforms related to the catenary
-    _material.set_shader_parameter("p0", p0)
-    _material.set_shader_parameter("p1", p1)
-    _material.set_shader_parameter("apq", Vector3(a, p, q))
-    _material.set_shader_parameter("arc_length", l)
-    _material.set_shader_parameter("flip_x", 1.0 if flip else 0.0)
+	# Set shader uniforms related to the catenary
+	_material.set_shader_parameter("p0", p0)
+	_material.set_shader_parameter("p1", p1)
+	_material.set_shader_parameter("apq", Vector3(a, p, q))
+	_material.set_shader_parameter("arc_length", l)
+	_material.set_shader_parameter("flip_x", 1.0 if flip else 0.0)

--- a/src/scripts/catenary.gd
+++ b/src/scripts/catenary.gd
@@ -144,7 +144,10 @@ func _create_mesh_instance() -> void:
 	# You may need to replace these uniforms based on what kind of shader is used on the mesh.
 	# These uniforms act as a standard SchlickGGX shader in Godot.
 	var material:StandardMaterial3D = mesh.surface_get_material(0)
-	_material.set_shader_parameter("albedo", material.albedo_texture)
+	_material.set_shader_parameter("albedo", material.albedo_color)
+	_material.set_shader_parameter("texture_albedo", material.albedo_texture)
+	_material.set_shader_parameter("metallic", material.metallic)
+	_material.set_shader_parameter("roughness", material.roughness)
 
 func _update_curve() -> void:
 	# Create a mesh instance of none exists

--- a/src/scripts/catenary.gd.uid
+++ b/src/scripts/catenary.gd.uid
@@ -1,0 +1,1 @@
+uid://bxbkgpvdk3e8p

--- a/src/scripts/suzanne.gd
+++ b/src/scripts/suzanne.gd
@@ -1,3 +1,4 @@
+@tool
 """
     Asset: Godot Dynamic Catenary
     File: suzenne.gd
@@ -6,8 +7,7 @@
     License: MIT License
 """
 
-tool
-extends Spatial
+extends Node3D
 
 var _total_seconds:float
 
@@ -36,20 +36,20 @@ func _process(delta:float) -> void:
         return
     
     var t:float = ease(min(1, 1.0 - _move_seconds / _move_duration), _move_easing)
-    translation = _start_position.linear_interpolate(_target_position, t)
+    position = _start_position.lerp(_target_position, t)
     rotation = Vector3(
         lerp_angle(_start_rotation.x, _target_rotation.x, t),
         lerp_angle(_start_rotation.y, _target_rotation.y, t),
         lerp_angle(_start_rotation.z, _target_rotation.z, t))
 
 func _start_move() -> void:
-    _move_duration = 1.1 + sin(_total_seconds) * rand_range(0.5, 1)
+    _move_duration = 1.1 + sin(_total_seconds) * randf_range(0.5, 1)
     _move_seconds = _move_duration
-    _move_easing = rand_range(-4, 4)
-    _wait_seconds = max(rand_range(-5, 1), 0)
+    _move_easing = randf_range(-4, 4)
+    _wait_seconds = max(randf_range(-5, 1), 0)
     
-    _start_position = translation
+    _start_position = position
     _start_rotation = rotation
     
-    _target_position = Vector3(0, 1.3, 0) + Vector3(rand_range(-0.5, 0.5), rand_range(-0.3, 0.3), rand_range(-0.5, 0.5))
-    _target_rotation = Vector3(rand_range(-0.5, 0.5), rand_range(-1, 1), rand_range(-0.5, 0.5))
+    _target_position = Vector3(0, 1.3, 0) + Vector3(randf_range(-0.5, 0.5), randf_range(-0.3, 0.3), randf_range(-0.5, 0.5))
+    _target_rotation = Vector3(randf_range(-0.5, 0.5), randf_range(-1, 1), randf_range(-0.5, 0.5))

--- a/src/scripts/suzanne.gd.uid
+++ b/src/scripts/suzanne.gd.uid
@@ -1,0 +1,1 @@
+uid://ndlckk32um6o

--- a/src/shaders/catenary.tres
+++ b/src/shaders/catenary.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Shader" format=2]
+[gd_resource type="Shader" format=3 uid="uid://c6blaqj5rgiqt"]
 
 [resource]
 code = "/*
@@ -13,8 +13,6 @@ code = "/*
 
 shader_type spatial;
 render_mode skip_vertex_transform; // Add additional render modes as needed.
-
-const float PI = 3.14159265359;
 
 // The mesh min-max x
 uniform vec2 minmax_x = vec2(0.0, 1.0);
@@ -84,22 +82,22 @@ void vertex() {
     vec3 world = c0 + p0 + swing + vec3(xz.x, 0, xz.y) + up * VERTEX.y * width;
 
     // Transform from world space to view space
-    VERTEX = (INV_CAMERA_MATRIX * vec4(world, 1.0)).xyz;
+    VERTEX = (VIEW_MATRIX * vec4(world, 1.0)).xyz;
 }
 
 // These are uniforms and a fragment shader based on the default Godot spatial material
 // Everything below this point can be replaced safely based on needs
 
-uniform vec4 albedo : hint_color;
-uniform sampler2D texture_albedo : hint_albedo;
+uniform vec4 albedo : source_color;
+uniform sampler2D texture_albedo : source_color;
 uniform float specular;
 uniform float metallic;
 uniform float alpha_scissor_threshold;
 uniform float roughness : hint_range(0,1);
-uniform sampler2D texture_metallic : hint_white;
-uniform sampler2D texture_roughness : hint_white;
-uniform sampler2D texture_emission : hint_black_albedo;
-uniform vec4 emission : hint_color;
+uniform sampler2D texture_metallic : hint_default_white;
+uniform sampler2D texture_roughness : hint_default_white;
+uniform sampler2D texture_emission : hint_default_black;
+uniform vec4 emission : source_color;
 uniform float emission_energy;
 uniform sampler2D texture_normal : hint_normal;
 uniform float normal_scale : hint_range(-16,16);
@@ -110,9 +108,9 @@ void fragment() {
     METALLIC = texture(texture_metallic, UV).r * metallic;
     ROUGHNESS = texture(texture_roughness, UV).r * roughness;
     SPECULAR = specular;
-    NORMALMAP = texture(texture_normal, UV).rgb;
-    NORMALMAP_DEPTH = normal_scale;
+    NORMAL_MAP = texture(texture_normal, UV).rgb;
+    NORMAL_MAP_DEPTH = normal_scale;
     EMISSION = (texture(texture_emission, UV).rgb + emission.rgb) * emission_energy;
     ALPHA = albedo_tex.a * albedo.a;
-    ALPHA_SCISSOR = alpha_scissor_threshold;
+    ALPHA_SCISSOR_THRESHOLD = alpha_scissor_threshold;
 }"


### PR DESCRIPTION
This PR updates `catenary.gd`, `catenary.tres`, and the demo project for Godot v4.4.

⚠️ Godot v4.4 is still in beta, so if you'd like to delay releasing or merging this, that is totally understandable!

Almost all of the changes in this PR were made automatically by the built-in project upgrade tool. Here is a list of all manual changes that I made:
- Added `.godot/` to `.gitignore`
- Added `*.uid` files to source control (this is a Godot 4.4-specific change, [see this announcement for details](https://godotengine.org/article/uid-changes-coming-to-godot-4-4/#what-should-i-change-in-my-project-or-workflow))
- In `catenary.gd`, changed the code that reads the mesh's shader properties and passes them as parameters to the catenary's shader, since the mesh materials have been automatically converted to StandardMaterial3D's
- In `catenary.tres`, removed the definition of `PI` to fix a compilation error (PI is now pre-defined)

Closes #1 